### PR TITLE
kaiabridge: Update KaiaBridge page to work with mainnet contract

### DIFF
--- a/src/hooks/page/useKaiaBridgePage.ts
+++ b/src/hooks/page/useKaiaBridgePage.ts
@@ -1,13 +1,16 @@
 import { useState, useEffect } from 'react'
-import { JsonRpcProvider, BrowserProvider, hashMessage, SigningKey, Contract, getBytes, sha256, ripemd160 } from 'ethers'
+import { JsonRpcProvider, BrowserProvider, hashMessage, SigningKey, Contract, getBytes, sha256, ripemd160, Interface } from 'ethers'
 import * as bech32lib from 'bech32'
 import type { BechLib } from 'bech32'
-import { useSignMessage, useWalletClient } from 'wagmi'
+import { useSignMessage, useWalletClient, useAccount } from 'wagmi'
 import { useNetwork } from '../independent'
 
-const BRIDGE_MESSAGE = 'KaiaBridge'
+const BRIDGE_MESSAGE_PREFIX = 'kaiabridge'
 // In the browser, Vite exposes bech32 functions directly on the module
 const bech32 = ((bech32lib as any).toWords ? bech32lib : bech32lib.bech32) as BechLib
+
+// Kaia Wallet (Kaia Wallet) provider
+const kaiaProvider = typeof window !== 'undefined' && typeof window.klaytn !== 'undefined' ? window.klaytn : null
 
 export type UseKaiaBridgePageReturn = {
   loading: boolean
@@ -36,6 +39,7 @@ export type UseKaiaBridgePageReturn = {
   balanceAfterClaim: string
   balanceBeforeClaimKaia: string
   balanceAfterClaimKaia: string
+  balanceDifferenceKaia: string
   checkingClaimed: boolean
 }
 
@@ -58,10 +62,18 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
   const [checkingClaimed, setCheckingClaimed] = useState(false)
   const [balanceBeforeClaim, setBalanceBeforeClaim] = useState('')
   const [balanceAfterClaim, setBalanceAfterClaim] = useState('')
+  const [signedMessage, setSignedMessage] = useState('') // Store the message that was signed
+  const [storedSignature, setStoredSignature] = useState('') // Store signature from either wallet
   const { rpcUrl } = useNetwork()
   const provider = new JsonRpcProvider(rpcUrl)
-  const { signMessageAsync, data: signature } = useSignMessage()
+  const { signMessageAsync } = useSignMessage()
   const { data: walletClient } = useWalletClient()
+  const { address: connectedAddress } = useAccount()
+
+  // Build the message to sign: "kaiabridge" + "0xuser_address"
+  const buildBridgeMessage = (address: string): string => {
+    return BRIDGE_MESSAGE_PREFIX + address.toLowerCase()
+  }
 
   const holderVerifierABI = [
     "function getRecord(string) view returns (uint256, uint64)",
@@ -74,8 +86,8 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     "function requestClaim(uint64)",
   ]
 
-  const holderVerifierKairosAddress = "0x6dc8f41BFfD51C20437df7B0eD5E17716802E4EF"
-  const bridgeKairosAddress = "0xF02C6c29611e7eC05e4429ce440E1fF40c9b730a"
+  const holderVerifierAddress = "0x6475aAcD6f7C58BE5814eD400E3f738d35DB4FB6"
+  const bridgeAddress = "0x5ff2ad57c15f7dacb5d098d1fc82daf482884f99"
 
   const pubkeyToFinschiaAddress = (pubkey: string) => {
     const pubKeyBytes = getBytes(pubkey)
@@ -88,15 +100,15 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     return finschiaAddress;
   }
 
-  const deriveFinschiaAddress = (sig: string) => {
-    const digest = hashMessage(BRIDGE_MESSAGE)
+  const deriveFinschiaAddress = (sig: string, message: string) => {
+    const digest = hashMessage(message)
     const recoveredPubKey = SigningKey.recoverPublicKey(digest, sig)
     const finschiaAddress = pubkeyToFinschiaAddress(recoveredPubKey)
     return finschiaAddress
   }
 
-  const getUncompressedPublicKey = (sig: string): string => {
-    const digest = hashMessage(BRIDGE_MESSAGE)
+  const getUncompressedPublicKey = (sig: string, message: string): string => {
+    const digest = hashMessage(message)
     const recoveredPubKey = SigningKey.recoverPublicKey(digest, sig)
     // recoverPublicKey returns uncompressed format (0x04 + x + y)
     return recoveredPubKey
@@ -111,12 +123,19 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     return `${kaia}.${decimals}`
   }
 
+  // Calculate difference using BigInt to avoid floating point precision issues
+  const calculateKaiaDifference = (beforeKei: string, afterKei: string): string => {
+    if (!beforeKei || !afterKei) return '0'
+    const diff = BigInt(afterKei) - BigInt(beforeKei)
+    return keiToKaia(diff.toString())
+  }
+
   const fetchRecord = async (address: string) => {
     setRecordLoading(true)
     setConyBalance('')
     setProvisionSeq('')
     try {
-      const holderVerifierContract = new Contract(holderVerifierKairosAddress, holderVerifierABI, provider)
+      const holderVerifierContract = new Contract(holderVerifierAddress, holderVerifierABI, provider)
       const result = await holderVerifierContract.getRecord(address)
       setConyBalance(result[0].toString())
       setProvisionSeq(result[1].toString())
@@ -129,6 +148,54 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     }
   }
 
+  // Get wallet address from either Kaia Wallet or MetaMask (wagmi)
+  const getWalletAddress = async (): Promise<string | null> => {
+    // Try Kaia Wallet first
+    if (kaiaProvider) {
+      try {
+        const accounts = await kaiaProvider.request({ method: 'eth_accounts' })
+        if (accounts && accounts.length > 0) {
+          return accounts[0]
+        }
+      } catch (e) {
+        console.log('Kaia Wallet not connected or error:', e)
+      }
+    }
+
+    // Fall back to wagmi (MetaMask)
+    if (connectedAddress) {
+      return connectedAddress
+    }
+
+    if (walletClient?.account?.address) {
+      return walletClient.account.address
+    }
+
+    return null
+  }
+
+  // Sign message using either Kaia Wallet or MetaMask (wagmi)
+  const signMessage = async (message: string, address: string): Promise<string> => {
+    // Try Kaia Wallet first if it has the address
+    if (kaiaProvider) {
+      try {
+        const accounts = await kaiaProvider.request({ method: 'eth_accounts' })
+        if (accounts && accounts.length > 0 && accounts[0].toLowerCase() === address.toLowerCase()) {
+          const sig = await kaiaProvider.request({
+            method: 'personal_sign',
+            params: [message, address]
+          })
+          return sig
+        }
+      } catch (e) {
+        console.log('Kaia Wallet signing failed, trying wagmi:', e)
+      }
+    }
+
+    // Fall back to wagmi (MetaMask)
+    return await signMessageAsync({ message })
+  }
+
   const signAndDerive = async () => {
     setErrorMsg('')
     setFinschiaAddress('')
@@ -138,11 +205,24 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     setProvisionTxHash('')
     setClaimJustSucceeded(false)
     setClaimTxHash('')
+    setSignedMessage('')
+    setStoredSignature('')
     setLoading(true)
 
     try {
-      const sig = await signMessageAsync({ message: BRIDGE_MESSAGE })
-      const fnsa = deriveFinschiaAddress(sig)
+      const walletAddress = await getWalletAddress()
+
+      if (!walletAddress) {
+        throw new Error('Wallet not connected. Please connect MetaMask or Kaia Wallet.')
+      }
+
+      // Build message to sign: "kaiabridge" + "0xuser_address"
+      const message = buildBridgeMessage(walletAddress)
+      setSignedMessage(message)
+
+      const sig = await signMessage(message, walletAddress)
+      setStoredSignature(sig) // Store the signature for provision request
+      const fnsa = deriveFinschiaAddress(sig, message)
       setFinschiaAddress(fnsa)
 
       // Automatically fetch record after deriving address
@@ -153,23 +233,6 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
       setLoading(false)
     }
   }
-
-  // Auto-derive when signature changes (from external signing)
-  useEffect(() => {
-    if (signature) {
-      try {
-        const fnsa = deriveFinschiaAddress(signature)
-        setFinschiaAddress(fnsa)
-        setProvisionJustSucceeded(false)
-        setProvisionTxHash('')
-        setClaimJustSucceeded(false)
-        setClaimTxHash('')
-        fetchRecord(fnsa)
-      } catch (err: any) {
-        setErrorMsg(err?.message || 'Failed to derive Finschia address')
-      }
-    }
-  }, [signature])
 
   // Check claimed status when provisionSeq changes
   useEffect(() => {
@@ -188,7 +251,7 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
 
     setCheckingClaimed(true)
     try {
-      const bridgeContract = new Contract(bridgeKairosAddress, bridgeABI, provider)
+      const bridgeContract = new Contract(bridgeAddress, bridgeABI, provider)
       const claimed = await bridgeContract.claimed(seq)
       setHasClaimed(claimed)
     } catch (err: any) {
@@ -210,11 +273,46 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
   }
 
   const getSigner = async () => {
-    if (!walletClient) {
-      throw new Error('Wallet not connected')
+    // Try wagmi (MetaMask) first since it's more reliable with ethers.js
+    if (walletClient) {
+      const browserProvider = new BrowserProvider(walletClient as any)
+      return await browserProvider.getSigner()
     }
-    const browserProvider = new BrowserProvider(walletClient as any)
-    return await browserProvider.getSigner()
+
+    // Fall back to Kaia Wallet
+    if (kaiaProvider) {
+      try {
+        const accounts = await kaiaProvider.request({ method: 'eth_accounts' })
+        if (accounts && accounts.length > 0) {
+          const browserProvider = new BrowserProvider(kaiaProvider as any)
+          return await browserProvider.getSigner()
+        }
+      } catch (e) {
+        console.log('Kaia Wallet signer failed:', e)
+      }
+    }
+
+    throw new Error('Wallet not connected')
+  }
+
+  // Send transaction using Kaia Wallet directly (bypasses ethers.js compatibility issues)
+  const sendTransactionViaKaiaWallet = async (to: string, data: string): Promise<string> => {
+    const accounts = await kaiaProvider.request({ method: 'eth_accounts' })
+    if (!accounts || accounts.length === 0) {
+      throw new Error('Kaia Wallet not connected')
+    }
+
+    const txHash = await kaiaProvider.request({
+      method: 'eth_sendTransaction',
+      params: [{
+        from: accounts[0],
+        to,
+        data,
+        gas: '0x4C4B40', // 5000000 gas
+      }]
+    })
+
+    return txHash
   }
 
   const handleRequestProvision = async () => {
@@ -223,8 +321,13 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
       return
     }
 
-    if (!signature) {
+    if (!storedSignature) {
       setProvisionError('Signature not found. Please sign the message again.')
+      return
+    }
+
+    if (!signedMessage) {
+      setProvisionError('Signed message not found. Please sign the message again.')
       return
     }
 
@@ -234,30 +337,51 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     setProvisionJustSucceeded(false)
 
     try {
-      const signer = await getSigner()
-
-      // Prepare the message hash
-      const messageHash = hashMessage(BRIDGE_MESSAGE)
+      // Prepare the message hash to sign
+      const messageHash = hashMessage(signedMessage)
 
       // Get the uncompressed public key from the signature
-      const publicKey = getUncompressedPublicKey(signature)
+      const publicKey = getUncompressedPublicKey(storedSignature, signedMessage)
 
-      const holderVerifierContract = new Contract(holderVerifierKairosAddress, holderVerifierABI, signer)
-      const tx = await holderVerifierContract.requestProvision(publicKey, finschiaAddress, messageHash, signature)
-      const receipt = await tx.wait()
+      let txHash: string
 
-      if (receipt && receipt.status === 1) {
-        setProvisionTxHash(receipt.hash)
-        setProvisionJustSucceeded(true)
+      // Check if we should use wagmi or Kaia Wallet
+      if (walletClient) {
+        // Use wagmi (MetaMask)
+        const signer = await getSigner()
+        const holderVerifierContract = new Contract(holderVerifierAddress, holderVerifierABI, signer)
+        const tx = await holderVerifierContract.requestProvision(publicKey, finschiaAddress, messageHash, storedSignature)
+        const receipt = await tx.wait()
+
+        if (receipt && receipt.status === 1) {
+          txHash = receipt.hash
+        } else {
+          throw new Error('Transaction failed')
+        }
+      } else if (kaiaProvider) {
+        // Use Kaia Wallet directly
+        const iface = new Interface(holderVerifierABI)
+        const data = iface.encodeFunctionData('requestProvision', [publicKey, finschiaAddress, messageHash, storedSignature])
+
+        txHash = await sendTransactionViaKaiaWallet(holderVerifierAddress, data)
+
+        // Wait for receipt using JsonRpcProvider
+        const receipt = await provider.waitForTransaction(txHash)
+        if (!receipt || receipt.status !== 1) {
+          throw new Error('Transaction failed')
+        }
       } else {
-        throw new Error('Transaction failed')
+        throw new Error('No wallet connected')
       }
+
+      setProvisionTxHash(txHash)
+      setProvisionJustSucceeded(true)
 
       // Refresh record after provision
       await fetchRecord(finschiaAddress)
 
       // Check claimed status for the new sequence
-      const holderVerifierContractRead = new Contract(holderVerifierKairosAddress, holderVerifierABI, provider)
+      const holderVerifierContractRead = new Contract(holderVerifierAddress, holderVerifierABI, provider)
       const newSeq = await holderVerifierContractRead.provisionSeq(finschiaAddress)
       await checkIfClaimed(newSeq.toString())
     } catch (err: any) {
@@ -281,23 +405,49 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     setClaimJustSucceeded(false)
 
     try {
-      const signer = await getSigner()
-      const walletAddress = await signer.getAddress()
+      // Get wallet address for balance checking
+      const walletAddress = await getWalletAddress()
+      if (!walletAddress) {
+        throw new Error('Wallet not connected')
+      }
 
       // Get balance before claim
       const balanceBefore = await getKaiaBalance(walletAddress)
       setBalanceBeforeClaim(balanceBefore)
 
-      const bridgeContract = new Contract(bridgeKairosAddress, bridgeABI, signer)
-      const tx = await bridgeContract.requestClaim(provisionSeq)
-      const receipt = await tx.wait()
+      let txHash: string
 
-      if (receipt && receipt.status === 1) {
-        setClaimTxHash(receipt.hash)
-        setClaimJustSucceeded(true)
+      // Check if we should use wagmi or Kaia Wallet
+      if (walletClient) {
+        // Use wagmi (MetaMask)
+        const signer = await getSigner()
+        const bridgeContract = new Contract(bridgeAddress, bridgeABI, signer)
+        const tx = await bridgeContract.requestClaim(provisionSeq)
+        const receipt = await tx.wait()
+
+        if (receipt && receipt.status === 1) {
+          txHash = receipt.hash
+        } else {
+          throw new Error('Transaction failed')
+        }
+      } else if (kaiaProvider) {
+        // Use Kaia Wallet directly
+        const iface = new Interface(bridgeABI)
+        const data = iface.encodeFunctionData('requestClaim', [provisionSeq])
+
+        txHash = await sendTransactionViaKaiaWallet(bridgeAddress, data)
+
+        // Wait for receipt using JsonRpcProvider
+        const receipt = await provider.waitForTransaction(txHash)
+        if (!receipt || receipt.status !== 1) {
+          throw new Error('Transaction failed')
+        }
       } else {
-        throw new Error('Transaction failed')
+        throw new Error('No wallet connected')
       }
+
+      setClaimTxHash(txHash)
+      setClaimJustSucceeded(true)
 
       // Get balance after claim
       const balanceAfter = await getKaiaBalance(walletAddress)
@@ -319,7 +469,7 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     finschiaAddress,
     signAndDerive,
     errorMsg,
-    signature: signature || '',
+    signature: storedSignature,
     conyBalance,
     provisionSeq,
     recordLoading,
@@ -341,6 +491,7 @@ export const useKaiaBridgePage = (): UseKaiaBridgePageReturn => {
     balanceAfterClaim,
     balanceBeforeClaimKaia: keiToKaia(balanceBeforeClaim),
     balanceAfterClaimKaia: keiToKaia(balanceAfterClaim),
+    balanceDifferenceKaia: calculateKaiaDifference(balanceBeforeClaim, balanceAfterClaim),
     checkingClaimed,
   }
 }


### PR DESCRIPTION
This PR adds the following changes:
- Set supported network to Kaia Mainnet (only) and update contract addresses to mainnet contract addresses
- Add "Switch Network" button for the users to conveniently switch network to Kaia Mainnet
- Update signing message to "kaiabridge" + "0xuser_address"
- Remove banner saying this is a "Testing Version"
- Remove warning saying "execute the test tx on kairos", because the user cannot test this in Kairos
- Calculate KAIA difference after claim using BigInt (previously float)
